### PR TITLE
Fix table width calculation for KLSWeb platforms

### DIFF
--- a/lib/src/operance_data_table.dart
+++ b/lib/src/operance_data_table.dart
@@ -1,6 +1,7 @@
 // 🐦 Flutter imports:
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/foundation.dart';
 
 // 🌎 Project imports:
 import 'package:operance_datatable/src/misc.dart';
@@ -292,9 +293,16 @@ class OperanceDataTableState<T> extends State<OperanceDataTable<T>> {
     final searchPosition = ui.searchPosition;
 
     return LayoutBuilder(builder: (context, constraints) {
-      final tableWidth = constraints.maxWidth > constraints.maxHeight
+      final bool isKLSWeb = kIsWeb && (defaultTargetPlatform == TargetPlatform.macOS ||
+          defaultTargetPlatform == TargetPlatform.windows ||
+          defaultTargetPlatform == TargetPlatform.linux);
+
+      final double tableWidth = isKLSWeb
           ? constraints.maxWidth
-          : constraints.maxHeight;
+          : constraints.maxWidth > constraints.maxHeight
+              ? constraints.maxWidth
+              : constraints.maxHeight;
+      
       final availableWidth = tableWidth - _extrasWidth;
       final tableHeight = constraints.maxHeight;
 


### PR DESCRIPTION
This commit addresses an issue where the expanded content width would change unexpectedly when the screen height changed, particularly on KLSWeb platforms. It introduces a platform-specific width calculation to ensure consistent table widths across different environments.